### PR TITLE
replace --template flag, using --with instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm create enchilada -l
 
 ### Template:
 ```
-npm create enchilada -- --template [template-name] [app-name]
+npm create enchilada -- --with [template-name] [app-name]
 ```
 or
 ```
@@ -62,13 +62,13 @@ npm create enchilada -- -t [template-name] [app-name]
 ```
 E.g:
 ```
-npm create enchilada -- --template vanilla-js my-app
+npm create enchilada -- --with vanilla-js my-app
 ```
 
 ### Scaffold into current directory:
 Use `.` as the app name to scaffold into the current directory instead of creating a new one:
 ```
-npm create enchilada -- --template vanilla-js .
+npm create enchilada -- --with vanilla-js .
 ```
 Or via interactive prompts, enter `.` when asked for the app name.
 

--- a/__tests__/unit/index.unit.test.js
+++ b/__tests__/unit/index.unit.test.js
@@ -10,7 +10,7 @@ afterEach(() => rm(genPath, { recursive: true, force: true }));
 
 describe('Passing arguments to main app', () => {
   test('Passing template and directory', () => {
-    const args = { _: [appNameMock], template: 'react' };
+    const args = { _: [appNameMock], with: 'react' };
     app(args);
 
     const packageJson = readFileSync(`${genPath}/package.json`, 'utf8');
@@ -18,7 +18,7 @@ describe('Passing arguments to main app', () => {
   });
 
   test('Passing template without directory', () => {
-    const args = { _: [], template: 'react' };
+    const args = { _: [], with: 'react' };
     app(args);
 
     let packageJson;
@@ -52,7 +52,7 @@ describe('Passing arguments to main app', () => {
   });
 
   test('Passing a invalid template', async () => {
-    const { stdout } = await execa`node index.js --template no-template ${appNameMock}`;
+    const { stdout } = await execa`node index.js --with no-template ${appNameMock}`;
     expect(stdout).toContain('Invalid Template');
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const resolveAndInitialize = (template, appName) => {
 };
 
 const app = async (args) => {
-  const templateArg = args.template || args.t;
+  const templateArg = args.with || args.t;
   const appNameArg = args._[0];
   const { help, h, list, l } = args;
 

--- a/src/utils/helpMessage.js
+++ b/src/utils/helpMessage.js
@@ -8,7 +8,7 @@ Options:
   directory                 The project's name in the current directory,
                             e.g., my-app, would be like ./my-app/
                             the directory should not exist.
-  -t, --template NAME       Use a specific template.
+  -t, --with NAME           Use a specific template.
   -l, --list                List all available templates with full stack details, and exit.
   -h, --help                Display a help message, and exit.
 


### PR DESCRIPTION
## Changes:
  - Replace `--template` flag with `--with` to avoid collision with npm 11's built-in config flags