### PR TITLE
Fix/errors validations security

### DIFF
--- a/__tests__/unit/appName.unit.test.js
+++ b/__tests__/unit/appName.unit.test.js
@@ -24,5 +24,7 @@ describe('App name fuctions', () => {
     expect(validateAppName('my-app_app')).toContain('App name should not contain special characters except hyphen (-)');
     expect(validateAppName('myapp!@(#&*(!@^$&*#&*@))')).toContain('App name should not contain special characters except hyphen (-)');
     expect(validateAppName('my_app')).toContain('App name should not contain special characters except hyphen (-)');
+    expect(validateAppName('a'.repeat(215))).toContain('App name must be 214 characters or fewer');
+    expect(validateAppName('a'.repeat(214))).toBe(true);
   });
 });

--- a/__tests__/unit/index.unit.test.js
+++ b/__tests__/unit/index.unit.test.js
@@ -52,7 +52,7 @@ describe('Passing arguments to main app', () => {
   });
 
   test('Passing a invalid template', async () => {
-    const { stdout } = await execa`node index.js --with no-template ${appNameMock}`;
-    expect(stdout).toContain('Invalid Template');
+    const { stderr } = await execa('node', ['index.js', '--with', 'no-template', appNameMock], { reject: false });
+    expect(stderr).toContain('Invalid Template');
   });
 });

--- a/__tests__/unit/initialize.unit.test.js
+++ b/__tests__/unit/initialize.unit.test.js
@@ -14,18 +14,14 @@ describe('Initialize app', () => {
     const packageJson = readFileSync(`${genPath}/package.json`, 'utf8');
     expect(packageJson).toContain(appNameMock);
   });
-  test('Attempt directory already exist', () => {
+  test('Throws when target directory already exists', async () => {
     mkdirSync(genPath, { recursive: true });
     copyFilesAndDirectories(sourcePath, genPath);
-    initialize(sourcePath, genPath, appNameMock);
-
-    const packageJson = readFileSync(`${genPath}/package.json`, 'utf8');
-    expect(packageJson).toContain('vanilla-js');
+    await expect(initialize(sourcePath, genPath, appNameMock)).rejects.toThrow('Target directory already exist!');
   });
-  test('Invalid template path does not create directory', () => {
+  test('Throws on invalid template path', async () => {
     const invalidSource = '/non/existent/template';
-    initialize(invalidSource, genPath, appNameMock);
-
+    await expect(initialize(invalidSource, genPath, appNameMock)).rejects.toThrow('Invalid Template');
     expect(existsSync(genPath)).toBe(false);
   });
 });

--- a/__tests__/unit/templateRenameName.unit.test.js
+++ b/__tests__/unit/templateRenameName.unit.test.js
@@ -17,9 +17,9 @@ describe('App name in package.json', () => {
     expect(packageJson).toContain(appNameMock);
   });
 
-  test('Handles missing package.json without throwing', () => {
+  test('Throws on missing package.json', () => {
     expect(() => {
       renamePackageJsonName('/non/existent/path', appNameMock);
-    }).not.toThrow();
+    }).toThrow('Failed to update package.json name');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-enchilada",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-enchilada",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-enchilada",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "description": "CLI scaffold tool to create web app projects from templates: React, Vanilla JS, Node/Express and more.",
   "main": "index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ import listMessage from './utils/listMessage';
 const argsv = minimist(argv.slice(2));
 
 const resolveAndInitialize = (template, appName) => {
-  const targetDirectory = path.join(process.cwd(), appName);
+  const safeName = appName === '.' ? '.' : path.basename(appName);
+  const targetDirectory = path.join(process.cwd(), safeName);
   const sourceDir = path.resolve(
     fileURLToPath(import.meta.url),
     '../../templates',
@@ -106,17 +107,22 @@ const app = async (args) => {
       resolveAndInitialize(templateResponse.template, appNameResponse.appName);
     } catch (err) {
       console.error(colors.error(err.message));
+      process.exit(1);
     }
   } else {
     try {
       resolveAndInitialize(templateArg, appNameArg);
     } catch (err) {
       console.error(colors.error(err.message));
+      process.exit(1);
     }
   }
   return 0;
 };
 
-app(argsv);
+app(argsv).catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});
 
 export default app;

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -10,13 +10,11 @@ async function initialize(sourcePath, destinationPath, name) {
   const isDestinationPath = existsSync(destinationPath);
 
   if (!isValidTemplate) {
-    console.log(colors.error('Invalid Template'));
-    return;
+    throw new Error('Invalid Template');
   }
 
   if (isDestinationPath && !isCurrentDir) {
-    console.log(colors.error('Target directory already exist!'));
-    return;
+    throw new Error('Target directory already exist!');
   }
 
   if (!isCurrentDir) {

--- a/src/templateCopy.js
+++ b/src/templateCopy.js
@@ -20,6 +20,8 @@ const copyFilesAndDirectories = (source, destination) => {
     try {
       const stat = lstatSync(sourcePath);
 
+      if (stat.isSymbolicLink()) return;
+
       if (stat.isDirectory()) {
         mkdirSync(destPath, { recursive: true });
         copyFilesAndDirectories(sourcePath, destPath);

--- a/src/templateRenameName.js
+++ b/src/templateRenameName.js
@@ -16,7 +16,7 @@ const renamePackageJsonName = (targetDir, nameApp) => {
       'utf8',
     );
   } catch (err) {
-    throw new Error(`Failed to update package.json name: ${err.message}`);
+    throw new Error(`Failed to update package.json name: ${err.message}`, { cause: err });
   }
 };
 

--- a/src/templateRenameName.js
+++ b/src/templateRenameName.js
@@ -16,7 +16,7 @@ const renamePackageJsonName = (targetDir, nameApp) => {
       'utf8',
     );
   } catch (err) {
-    console.log(err.message);
+    throw new Error(`Failed to update package.json name: ${err.message}`);
   }
 };
 

--- a/src/utils/appName.js
+++ b/src/utils/appName.js
@@ -1,4 +1,10 @@
 const formatAppName = (name) => name === '.' ? '.' : name.toLowerCase().split(/[\s|_]/).join('-');
-const validateAppName = (name) => name === '.' || !name.match(/[^a-zA-Z0-9-\s]/g) ? true : 'App name should not contain special characters except hyphen (-)';
+
+const validateAppName = (name) => {
+  if (name === '.') return true;
+  if (name.length > 214) return 'App name must be 214 characters or fewer';
+  if (name.match(/[^a-zA-Z0-9-\s]/g)) return 'App name should not contain special characters except hyphen (-)';
+  return true;
+};
 
 export { formatAppName, validateAppName };


### PR DESCRIPTION
## Changes:
- Prevent path traversal by sanitizing `appName` with `path.basename()` before joining with `process.cwd()`
- Skip symlinks during recursive template copy to block symlink-based escape attacks
- Throw errors in `initialize` and `renamePackageJsonName` instead of swallowing them; CLI catches and exits with code `1`
- Add `.catch()` on `app()` call to surface unhandled async errors
- Validate app name length against npm's 214-character limit